### PR TITLE
tags

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,10 @@ trigger:
 pr:
 - master
 
+variables:
+  version: '1.0'
+  imageNamePrefix: nicholasescalona/
+
 stages:
 
 - stage: build
@@ -21,8 +25,24 @@ stages:
       inputs:
         containerregistrytype: 'Container Registry'
         dockerComposeFile: 'docker-compose.prod.yml'
+        dockerComposeFileArgs: 'TAG=$(version)-$(Build.BuildNumber)'
         action: 'Build services'
       displayName: docker-compose build
+
+    - task: DockerCompose@0
+      inputs:
+        containerregistrytype: 'Container Registry'
+        dockerRegistryEndpoint: 'dockerhub-nicholasescalona'
+        dockerComposeFile: 'docker-compose.prod.yml'
+        dockerComposeFileArgs: 'TAG=$(version)-$(Build.BuildNumber)'
+        action: 'Push services'
+      displayName: docker-compose push
+
+    - script: find k8s/deployment -type f | xargs sed -Ei 's|([a-z0-9._-]*:)rewrite$|$(imageNamePrefix)\1$(version)-$(Build.BuildNumber)|g'
+      displayName: k8s manifest rewrite
+
+    - publish: k8s
+      artifact: k8s
 
   - job: test
 
@@ -113,31 +133,15 @@ stages:
         deploy:
           steps:
 
-          - checkout: self
-
-          - download: none
-
-          - task: DockerCompose@0
-            inputs:
-              containerregistrytype: 'Container Registry'
-              dockerComposeFile: 'docker-compose.prod.yml'
-              action: 'Build services'
-            displayName: docker-compose build
-
-          - task: DockerCompose@0
-            inputs:
-              containerregistrytype: 'Container Registry'
-              dockerRegistryEndpoint: 'dockerhub-nicholasescalona'
-              dockerComposeFile: 'docker-compose.prod.yml'
-              action: 'Push services'
-            displayName: docker-compose push
+          - download: current
+            artifact: k8s
 
           - task: KubernetesManifest@0
             inputs:
               action: 'deploy'
               kubernetesServiceConnection: 'dev-default-1588463473433'
               namespace: 'default'
-              manifests: 'k8s/**/*.yml'
+              manifests: '$(Pipeline.Workspace)/k8s/**/*.yml'
             displayName: kubectl apply
 
           - task: Kubernetes@1
@@ -146,7 +150,7 @@ stages:
               kubernetesServiceEndpoint: 'dev-default-1588463473433'
               command: 'rollout'
               useConfigurationFile: true
-              configuration: 'k8s/deployment'
+              configuration: '$(Pipeline.Workspace)/k8s/deployment'
               arguments: 'restart'
               secretType: 'dockerRegistry'
               containerRegistryType: 'Azure Container Registry'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,8 +47,9 @@ stages:
       displayName: k8s manifest publish
       condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       inputs:
-        targetPath: k8s
-        artifactName: k8s
+        targetPath: 'k8s'
+        artifact: 'k8s'
+        publishLocation: 'pipeline'
 
   - job: test
 
@@ -138,11 +139,6 @@ stages:
       runOnce:
         deploy:
           steps:
-
-          - task: DownloadPipelineArtifact@2
-            displayName: k8s manifest download
-            inputs:
-              artifact: k8s
 
           - task: KubernetesManifest@0
             displayName: kubectl apply

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,7 @@ stages:
 
     - publish: k8s
       artifact: k8s
+      displayName: k8s manifest publish
 
   - job: test
 
@@ -135,6 +136,7 @@ stages:
 
           - download: current
             artifact: k8s
+            displayName: k8s manifest download
 
           - task: KubernetesManifest@0
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,28 +22,34 @@ stages:
     steps:
 
     - task: DockerCompose@0
+      displayName: docker-compose build
       inputs:
         containerregistrytype: 'Container Registry'
         dockerComposeFile: 'docker-compose.prod.yml'
         dockerComposeFileArgs: 'TAG=$(version)-$(Build.BuildNumber)'
         action: 'Build services'
-      displayName: docker-compose build
 
     - task: DockerCompose@0
+      displayName: docker-compose push
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       inputs:
         containerregistrytype: 'Container Registry'
         dockerRegistryEndpoint: 'dockerhub-nicholasescalona'
         dockerComposeFile: 'docker-compose.prod.yml'
         dockerComposeFileArgs: 'TAG=$(version)-$(Build.BuildNumber)'
         action: 'Push services'
-      displayName: docker-compose push
 
-    - script: find k8s/deployment -type f | xargs sed -Ei 's|([a-z0-9._-]*:)rewrite$|$(imageNamePrefix)\1$(version)-$(Build.BuildNumber)|g'
+    - bash: find k8s/deployment -type f | xargs sed -Ei 's|([a-z0-9._-]*:)rewrite$|$(imageNamePrefix)\1$(version)-$(Build.BuildNumber)|g'
       displayName: k8s manifest rewrite
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
-    - publish: k8s
-      artifact: k8s
+
+    - task: PublishPipelineArtifact@1
       displayName: k8s manifest publish
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      inputs:
+        targetPath: k8s
+        artifactName: k8s
 
   - job: test
 
@@ -58,12 +64,13 @@ stages:
     steps:
 
     - task: UseDotNet@2
+      displayName: dotnet 2.1.x
       inputs:
         packageType: 'sdk'
         version: '2.1.x'
-      displayName: dotnet 2.1.x
 
     - task: SonarCloudPrepare@1
+      displayName: sonarcloud analysis prepare
       inputs:
         SonarCloud: 'sonarcloud-escalonn'
         organization: '2002-feb24-net'
@@ -71,18 +78,17 @@ stages:
         projectKey: '2002-feb24-net_nick-project2-notes-api'
         projectName: 'nick-project2-notes-api'
         extraProperties: 'sonar.cs.opencover.reportsPaths=$(Common.TestResultsDirectory)/*/coverage.opencover.xml'
-      displayName: sonarcloud analysis prepare
 
     - task: UseDotNet@2
+      displayName: dotnet $(sdkVersion)
       inputs:
         packageType: 'sdk'
         version: '$(sdkVersion)'
-      displayName: dotnet $(sdkVersion)
 
     - script: dotnet build
         --configuration $(buildConfiguration)
-      workingDirectory: $(solutionPath)
       displayName: dotnet build
+      workingDirectory: $(solutionPath)
 
     - script: dotnet test
         --configuration $(buildConfiguration)
@@ -90,31 +96,31 @@ stages:
         --no-build
         --results-directory $(Common.TestResultsDirectory)
         --settings coverlet.runsettings
-      workingDirectory: $(solutionPath)
       displayName: dotnet test
+      workingDirectory: $(solutionPath)
 
     - task: SonarCloudAnalyze@1
       displayName: sonarcloud analysis run
 
     - task: PublishTestResults@2
+      displayName: test results build publish
       condition: succeededOrFailed()
       inputs:
         testResultsFormat: 'VSTest'
         testResultsFiles: '$(Common.TestResultsDirectory)/*.trx'
-      displayName: test results build publish
 
     - task: PublishCodeCoverageResults@1
+      displayName: code coverage build publish
       condition: succeededOrFailed()
       inputs:
         codeCoverageTool: Cobertura
         summaryFileLocation: $(Common.TestResultsDirectory)/*/coverage.cobertura.xml
-      displayName: code coverage build publish
 
     - task: SonarCloudPublish@1
+      displayName: sonarcloud results build publish
       condition: succeededOrFailed()
       inputs:
         pollingTimeoutSec: '300'
-      displayName: sonarcloud results build publish
 
 - stage: deploy
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
@@ -134,19 +140,21 @@ stages:
         deploy:
           steps:
 
-          - download: current
-            artifact: k8s
+          - task: DownloadPipelineArtifact@2
             displayName: k8s manifest download
+            inputs:
+              artifact: k8s
 
           - task: KubernetesManifest@0
+            displayName: kubectl apply
             inputs:
               action: 'deploy'
               kubernetesServiceConnection: 'dev-default-1588463473433'
               namespace: 'default'
               manifests: '$(Pipeline.Workspace)/k8s/**/*.yml'
-            displayName: kubectl apply
 
           - task: Kubernetes@1
+            displayName: kubectl rollout restart
             inputs:
               connectionType: 'Kubernetes Service Connection'
               kubernetesServiceEndpoint: 'dev-default-1588463473433'
@@ -156,4 +164,3 @@ stages:
               arguments: 'restart'
               secretType: 'dockerRegistry'
               containerRegistryType: 'Azure Container Registry'
-            displayName: kubectl rollout restart

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,6 @@ stages:
       displayName: k8s manifest rewrite
       condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
-
     - task: PublishPipelineArtifact@1
       displayName: k8s manifest publish
       condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,10 +9,10 @@ services:
     build:
       context: NotesService
       dockerfile: api.Dockerfile
-    image: nicholasescalona/2002-notes-api:${TAG}
+    image: ${IMAGENAMEPREFIX}2002-notes-api:${TAG}
 
   data:
     build:
       context: NotesService
       dockerfile: db.Dockerfile
-    image: nicholasescalona/2002-notes-db:${TAG}
+    image: ${IMAGENAMEPREFIX}2002-notes-db:${TAG}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,10 +9,10 @@ services:
     build:
       context: NotesService
       dockerfile: api.Dockerfile
-    image: nicholasescalona/2002-notes-api:1.0
+    image: nicholasescalona/2002-notes-api:${TAG}
 
   data:
     build:
       context: NotesService
       dockerfile: db.Dockerfile
-    image: nicholasescalona/2002-notes-db:1.0
+    image: nicholasescalona/2002-notes-db:${TAG}

--- a/k8s/deployment/notes-api.yml
+++ b/k8s/deployment/notes-api.yml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: notes-api
-        image: nicholasescalona/2002-notes-api
+        image: 2002-notes-api:rewrite
         ports:
         - containerPort: 80
         env:

--- a/k8s/deployment/notes-api.yml
+++ b/k8s/deployment/notes-api.yml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: notes-api
-        image: nicholasescalona/2002-notes-api:1.0
+        image: nicholasescalona/2002-notes-api
         ports:
         - containerPort: 80
         env:

--- a/k8s/deployment/notes-db.yml
+++ b/k8s/deployment/notes-db.yml
@@ -19,6 +19,6 @@ spec:
     spec:
       containers:
       - name: notes-db
-        image: nicholasescalona/2002-notes-db:1.0
+        image: nicholasescalona/2002-notes-db
         ports:
         - containerPort: 5432

--- a/k8s/deployment/notes-db.yml
+++ b/k8s/deployment/notes-db.yml
@@ -19,6 +19,6 @@ spec:
     spec:
       containers:
       - name: notes-db
-        image: nicholasescalona/2002-notes-db
+        image: 2002-notes-db:rewrite
         ports:
         - containerPort: 5432


### PR DESCRIPTION
use different docker image tags for each build, allowing for the build job to push its images to the registry (even if the tests will fail) and the deploy job to simply pull them instead of rebuilding.

i was hoping for a nicer solution than find/sed/regex, but it seems like that's the best i have unless i want to upgrade to helm.